### PR TITLE
4 th week my operating system creation, I have those errors, I need t…

### DIFF
--- a/gdt.s
+++ b/gdt.s
@@ -1,0 +1,19 @@
+
+global segments_load_gdt
+global segments_load_registers
+
+segments_load_gdt:
+	lgdt [esp + 4]
+	ret
+
+segments_load_registers:
+	mov ax, 0x10
+	mov ds, ax ; 0x10 - an offset into GDT for the third (kernel data segment) record.
+	mov ss, ax
+	mov es, ax
+	mov fs, ax
+	mov gs, ax
+	jmp 0x08:flush_cs ; 0x08 - an offset into GDT for the second (kernel code segment) record. 
+
+flush_cs:
+	ret

--- a/link.ld
+++ b/link.ld
@@ -1,0 +1,26 @@
+ENTRY(loader)                /* the name of the entry label */
+
+SECTIONS {
+    . = 0x00100000;          /* the code should be loaded at 1 MB */
+
+    .text ALIGN (0x1000) :   /* align at 4 KB */
+    {
+        *(.text)             /* all text sections from all files */
+    }
+
+    .rodata ALIGN (0x1000) : /* align at 4 KB */
+    {
+        *(.rodata*)          /* all read-only data sections from all files */
+    }
+
+    .data ALIGN (0x1000) :   /* align at 4 KB */
+    {
+        *(.data)             /* all data sections from all files */
+    }
+
+    .bss ALIGN (0x1000) :    /* align at 4 KB */
+    {
+        *(COMMON)            /* all COMMON sections from all files */
+        *(.bss)              /* all bss sections from all files */
+    }
+}

--- a/memory_seg.c
+++ b/memory_seg.c
@@ -1,0 +1,58 @@
+#include "memory_seg.h"
+
+#define SEGMENT_DESCRIPTOR_COUNT 3
+
+#define SEGMENT_BASE 0
+#define SEGMENT_LIMIT 0xFFFFF
+
+#define SEGMENT_CODE_TYPE 0x9A
+#define SEGMENT_DATA_TYPE 0x92
+
+/*
+ * Flags part of `limit_and_flags`.
+ * 1100
+ * 0 - Available for system use
+ * 0 - Long mode
+ * 1 - Size (0 for 16-bit, 1 for 32)
+ * 1 - Granularity (0 for 1B - 1MB, 1 for 4KB - 4GB)
+*/
+#define SEGMENT_FLAGS_PART 0x0C
+
+static struct GDTDescriptor gdt_descriptors[SEGMENT_DESCRIPTOR_COUNT];
+void segments_init_descriptor(int index, unsigned int base_address, unsigned int limit, unsigned char access_byte, unsigned char flags)
+{
+	gdt_descriptors[index].base_low = base_address & 0xFFFF;
+	gdt_descriptors[index].base_middle = (base_address >> 16) & 0xFF;
+	gdt_descriptors[index].base_high = (base_address >> 24) & 0xFF;
+
+	gdt_descriptors[index].limit_low = limit & 0xFFFF;
+	gdt_descriptors[index].limit_and_flags = (limit >> 16) & 0xF;
+	gdt_descriptors[index].limit_and_flags |= (flags << 4) & 0xF0;
+
+	gdt_descriptors[index].access_byte = access_byte;
+}
+void segments_install_gdt()
+{
+	gdt_descriptors[0].base_low = 0;
+	gdt_descriptors[0].base_middle = 0;
+	gdt_descriptors[0].base_high = 0;
+	gdt_descriptors[0].limit_low = 0;
+	gdt_descriptors[0].access_byte = 0;
+	gdt_descriptors[0].limit_and_flags = 0;
+
+	// The null descriptor which is never referenced by the processor. 
+        // Certain emulators, like Bochs, will complain about limit exceptions if you do not have one present. 
+        // Some use this descriptor to store a pointer to the GDT itself (to use with the LGDT instruction).
+        // The null descriptor is 8 bytes wide and the pointer is 6 bytes wide so it might just be the perfect place for this.
+        // From:  http://wiki.osdev.org/GDT_Tutorial
+	struct GDT* gdt_ptr = (struct GDT*)gdt_descriptors;
+	gdt_ptr->address = (unsigned int)gdt_descriptors;
+	gdt_ptr->size = (sizeof(struct GDTDescriptor) * SEGMENT_DESCRIPTOR_COUNT) - 1;
+
+	// See http://wiki.osdev.org/GDT_Tutorial
+	segments_init_descriptor(1, SEGMENT_BASE, SEGMENT_LIMIT, SEGMENT_CODE_TYPE, SEGMENT_FLAGS_PART);
+	segments_init_descriptor(2, SEGMENT_BASE, SEGMENT_LIMIT, SEGMENT_DATA_TYPE, SEGMENT_FLAGS_PART);
+
+	segments_load_gdt(*gdt_ptr);
+	segments_load_registers();
+}

--- a/memory_seg.h
+++ b/memory_seg.h
@@ -1,0 +1,27 @@
+#ifndef INCLUDE_MEMORY_SEGMENTS
+#define INCLUDE_MEMORY_SEGMENTS
+
+struct GDT 
+{
+	unsigned short size;
+	unsigned int address;
+} __attribute__((packed));
+
+struct GDTDescriptor
+{
+	unsigned short limit_low;
+	unsigned short base_low;
+	unsigned char base_middle;
+	unsigned char access_byte;
+	unsigned char limit_and_flags;
+	unsigned char base_high;
+} __attribute__((packed));
+
+void segments_init_descriptor(int index, unsigned int base_address, unsigned int limit, unsigned char access_byte, unsigned char flags);
+void segments_install_gdt();
+
+// Wrappers around ASM.
+void segments_load_gdt(struct GDT gdt);
+void segments_load_registers();
+
+#endif /* INCLUDE_MEMORY_SEGMENTS */


### PR DESCRIPTION
…o find solutions.

gcc -m32 -nostdlib -nostdinc -fno-builtin -fno-stack-protector -nostartfiles -nodefaultlibs -Wall -Wextra -Werror -c  kmain.c -o kmain.o
In file included from kmain.c:1:
frame_buffer.h: In function ‘fb_write_cell’:
frame_buffer.h:54:3: error: ‘fb’ undeclared (first use in this function); did you mean ‘fg’?
   54 |   fb[i] = c;
      |   ^~
      |   fg
frame_buffer.h:54:3: note: each undeclared identifier is reported only once for each function it appears in
frame_buffer.h:55:44: error: expected ‘)’ before ‘;’ token
   55 |   fb[i+1] = ((fg & 0x0F) << 4 | (bg & 0x0F);
      |             ~                              ^
      |                                            )
frame_buffer.h:55:45: error: expected ‘;’ before ‘}’ token
   55 |   fb[i+1] = ((fg & 0x0F) << 4 | (bg & 0x0F);
      |                                             ^
      |                                             ;
   56 |  }
      |  ~                                           
frame_buffer.h: In function ‘fb_write’:
frame_buffer.h:68:19: error: ‘writing_state’ undeclared (first use in this function)
   68 |    fb_write_cell((writing_state+(i*2)), *(buf+i), FB_GREEN, FB_DARK_GREY);
      |                   ^~~~~~~~~~~~~
frame_buffer.h:71:3: error: ‘cursor_state’ undeclared (first use in this function)
   71 |   cursor_state+=len;
      |   ^~~~~~~~~~~~
In file included from kmain.c:2:
serial_port.h: At top level:
serial_port.h:41:8: error: redeclaration of ‘enum BaudRate’
   41 |   enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |        ^~~~~~~~
serial_port.h:23:6: note: originally defined here
   23 | enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |      ^~~~~~~~
serial_port.h:41:19: error: redeclaration of enumerator ‘Baud_115200’
   41 |   enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                   ^~~~~~~~~~~
serial_port.h:23:17: note: previous definition of ‘Baud_115200’ was here
   23 | enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                 ^~~~~~~~~~~
serial_port.h:41:36: error: redeclaration of enumerator ‘Baud_57600’
   41 |   enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                                    ^~~~~~~~~~
serial_port.h:23:34: note: previous definition of ‘Baud_57600’ was here
   23 | enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                                  ^~~~~~~~~~
serial_port.h:41:48: error: redeclaration of enumerator ‘Baud_19200’
   41 |   enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                                                ^~~~~~~~~~
serial_port.h:23:46: note: previous definition of ‘Baud_19200’ was here
   23 | enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                                              ^~~~~~~~~~
serial_port.h:41:60: error: redeclaration of enumerator ‘Baud_9600’
   41 | enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                                                          ^~~~~~~~~

serial_port.h:23:58: note: previous definition of ‘Baud_9600’ was here
   23 | enum BaudRate { Baud_115200 = 1, Baud_57600, Baud_19200, Baud_9600 };
      |                                                          ^~~~~~~~~
serial_port.h: In function ‘serial_write’:
serial_port.h:115:7: error: implicit declaration of function ‘serial_configure’; did you mean ‘serial_configure_line’? [-Werror=implicit-function-declaration]
  115 |       serial_configure(com , divisor);
      |       ^~~~~~~~~~~~~~~~
      |       serial_configure_line
serial_port.h:119:12: error: implicit declaration of function ‘serial_write_byte’; did you mean ‘serial_write’? [-Werror=implicit-function-declaration]
  119 |            serial_write_byte(com, buf[indexToBuffer]);
      |            ^~~~~~~~~~~~~~~~~
      |            serial_write
serial_port.h: At top level:
serial_port.h:132:6: error: conflicting types for ‘serial_write_byte’ [-Werror]
  132 | void serial_write_byte(unsigned short port, char byteData)
      |      ^~~~~~~~~~~~~~~~~
serial_port.h:119:12: note: previous implicit declaration of ‘serial_write_byte’ was here
  119 |            serial_write_byte(com, buf[indexToBuffer]);
      |            ^~~~~~~~~~~~~~~~~
serial_port.h:143:6: error: conflicting types for ‘serial_configure’ [-Werror]
  143 | void serial_configure(unsigned short port, unsigned short baudRate)
      |      ^~~~~~~~~~~~~~~~
serial_port.h:115:7: note: previous implicit declaration of ‘serial_configure’ was here
  115 |       serial_configure(com , divisor);
      |       ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:31: kmain.o] Error 1